### PR TITLE
#098-일기 목록 작성 1,2 dataClass, DiaryRepository Interface 작성

### DIFF
--- a/app/src/main/java/teamh/boostcamp/myapplication/data/local/room/AppDatabase.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/local/room/AppDatabase.java
@@ -17,13 +17,15 @@ import androidx.room.Room;
 import androidx.room.RoomDatabase;
 import androidx.sqlite.db.SupportSQLiteDatabase;
 import io.reactivex.disposables.CompositeDisposable;
+import io.reactivex.schedulers.Schedulers;
 import teamh.boostcamp.myapplication.data.local.room.dao.AppDao;
 import teamh.boostcamp.myapplication.data.local.room.dao.DiaryDao;
+import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
 import teamh.boostcamp.myapplication.data.model.Diary;
 import teamh.boostcamp.myapplication.data.model.Memory;
 import teamh.boostcamp.myapplication.data.model.Recommendation;
 
-@Database(entities = {Diary.class, Recommendation.class, Memory.class}, version = 4, exportSchema = false)
+@Database(entities = {DiaryEntity.class, Recommendation.class, Memory.class}, version = 5, exportSchema = false)
 public abstract class AppDatabase extends RoomDatabase {
 
     private static final String DB_NAME = "appDB.db";
@@ -40,10 +42,11 @@ public abstract class AppDatabase extends RoomDatabase {
                             .fallbackToDestructiveMigration()
                             .addCallback(new Callback() {
                                 @Override
-                                public void onCreate(@NonNull SupportSQLiteDatabase db) {
+                                public void onOpen(@NonNull SupportSQLiteDatabase db) {
                                     super.onCreate(db);
                                     // 생성 callback
-                                    getInstance(context).diaryDao().insertDiary(Diary.generateSampleDiaryData())
+                                    INSTANCE.diaryDao().insertDiary(DiaryEntity.generateSampleDiaryData())
+                                            .subscribeOn(Schedulers.io())
                                             .subscribe(
                                                     () -> Log.d("Test", "임시 파일 생성"),
                                                     throwable -> Log.d("Test", "")

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/local/room/dao/AppDao.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/local/room/dao/AppDao.java
@@ -11,6 +11,7 @@ import androidx.room.Query;
 import io.reactivex.Completable;
 import io.reactivex.Flowable;
 import io.reactivex.Single;
+import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
 import teamh.boostcamp.myapplication.data.model.Diary;
 import teamh.boostcamp.myapplication.data.model.Memory;
 import teamh.boostcamp.myapplication.data.model.Recommendation;
@@ -24,10 +25,10 @@ public interface AppDao {
     Single<List<Diary>> loadMoreDiary(final int idx);
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    Completable insertDiary(Diary ...diaries);
+    Completable insertDiary(DiaryEntity...diaries);
 
     @Delete
-    void deleteDiary(Diary diary);
+    void deleteDiary(DiaryEntity diary);
 
     @Query("SELECT * FROM diary WHERE diary.recordDate > :start AND diary.recordDate < :end AND diary.selectedEmotion = :emotion LIMIT 5")
     Flowable<List<Diary>> getSelectedRecord(String start, String end, int emotion);
@@ -55,7 +56,7 @@ public interface AppDao {
     Single<Diary> loadSelectedDiary(int diaryId);
 
     @Query("SELECT diary.* FROM diary, recommended WHERE recommended.memoryId=:memoryId AND recommended.diaryId == diary.id")
-    Single<List<Diary>> loadSelectedDiayLista(int memoryId);
+    Single<List<Diary>> loadSelectedDiaryLista(int memoryId);
 
     // Graph 관련
     @Query("SELECT diary.tags, diary.selectedEmotion, diary.analyzedEmotion " +

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/local/room/dao/DiaryDao.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/local/room/dao/DiaryDao.java
@@ -9,22 +9,22 @@ import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
 import io.reactivex.Completable;
 import io.reactivex.Single;
-import teamh.boostcamp.myapplication.data.model.Diary;
+import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
 
 /*
  * DiaryDao 관련 */
 @Dao
 public interface DiaryDao {
 
-    @Query("SELECT * FROM diary WHERE timeStamp < :timeStamp ORDER BY timeStamp DESC LIMIT 3")
-    Single<List<Diary>> loadMoreDiary(final long timeStamp);
+    @Query("SELECT * FROM diary WHERE id < :id ORDER BY timeStamp DESC LIMIT 3")
+    Single<List<DiaryEntity>> loadMoreDiary(final int id);
 
     @Query("DELETE FROM diary")
     void deleteAll();
 
     @Delete
-    Completable deleteDiary(Diary diary);
+    Completable deleteDiary(DiaryEntity diary);
 
     @Insert(onConflict = OnConflictStrategy.REPLACE)
-    Completable insertDiary(Diary ...diaries);
+    Completable insertDiary(DiaryEntity ...diaries);
 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/local/room/entity/DiaryEntity.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/local/room/entity/DiaryEntity.java
@@ -1,0 +1,137 @@
+package teamh.boostcamp.myapplication.data.local.room.entity;
+
+import android.util.Log;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+import java.util.Locale;
+import java.util.Random;
+
+import androidx.annotation.NonNull;
+import androidx.room.ColumnInfo;
+import androidx.room.Entity;
+import androidx.room.PrimaryKey;
+
+/*
+ * Diary Entity 분리 */
+@Entity(tableName = "diary")
+public class DiaryEntity {
+
+    // DB 에서 인식하기 위한 PK
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(name = "id")
+    private final int id;
+
+    // 저장한 날
+    @ColumnInfo(name = "recordDate")
+    @NonNull
+    private final String recordDate;
+
+    // 저장된 파일 경로
+    @ColumnInfo(name = "recordFilePath")
+    @NonNull
+    private final String recordFilePath;
+
+    // 설정한 태그들
+    @ColumnInfo(name = "tags")
+    private final String tags;
+
+    // 선택한 감정 번호
+    @ColumnInfo(name = "selectedEmotion")
+    private final int selectedEmotion;
+
+    // API 를 통해 분석된 감정
+    @ColumnInfo(name = "analyzedEmotion")
+    private final int analyzedEmotion;
+
+    // TimeStamp 추가
+    @ColumnInfo(name = "timeStamp")
+    private final long timeStamp;
+
+    public DiaryEntity(int id,
+                       @NonNull String recordDate,
+                       @NonNull String recordFilePath,
+                       @NonNull String tags,
+                       final int selectedEmotion,
+                       final int analyzedEmotion,
+                       final long timeStamp) {
+        this.id = id;
+        this.recordDate = recordDate;
+        this.recordFilePath = recordFilePath;
+        this.tags = tags;
+        this.selectedEmotion = selectedEmotion;
+        this.analyzedEmotion = analyzedEmotion;
+        this.timeStamp = timeStamp;
+    }
+
+    /*최대한 안바뀌게 -> final */
+    public int getId() {
+        return id;
+    }
+
+    @NonNull
+    public String getRecordDate() {
+        return recordDate;
+    }
+
+    @NonNull
+    public String getTags() {
+        return tags;
+    }
+
+    @NonNull
+    public String getRecordFilePath() {
+        return recordFilePath;
+    }
+
+    public int getSelectedEmotion() {
+        return selectedEmotion;
+    }
+
+    public int getAnalyzedEmotion() {
+        return analyzedEmotion;
+    }
+
+    public long getTimeStamp() {
+        return timeStamp;
+    }
+
+    public static DiaryEntity[] generateSampleDiaryData() {
+        String filePath = "/storage/emulated/0/2019-02-08.acc";
+        File file = new File("/storage/emulated/0/2019-02-08.acc");
+
+        if (!file.exists()) {
+            try {
+                boolean isCreated = file.createNewFile();
+                if (!isCreated) {
+                    Log.e("Test", "파일 생성 실패");
+                } else {
+                    Log.e("Test", "파일 생성 성공");
+                }
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+        }
+
+        Random random = new Random();
+
+        List<DiaryEntity> samples = new ArrayList<>();
+
+        for (int i = 1; i <= 20; ++i) {
+            samples.add(new DiaryEntity(
+                    i,
+                    String.format(Locale.getDefault(), "2019-01-%2d", i),
+                    filePath,
+                    String.format(Locale.getDefault(), "#%d번", i),
+                    Math.abs(random.nextInt() % 5),
+                    Math.abs(random.nextInt() % 5),
+                    new Date().getTime() / 1000 + i * 10
+            ));
+        }
+
+        return samples.toArray(new DiaryEntity[samples.size()]);
+    }
+}

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/model/Diary.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/model/Diary.java
@@ -1,70 +1,27 @@
 package teamh.boostcamp.myapplication.data.model;
 
-import android.util.Log;
-
-import java.io.File;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.Date;
-import java.util.List;
-import java.util.Locale;
-import java.util.Random;
-
 import androidx.annotation.NonNull;
-import androidx.room.ColumnInfo;
-import androidx.room.Entity;
-import androidx.room.PrimaryKey;
 
 /*
  * 일기 아이템 데이터를 가지는 DataClass */
-@Entity(tableName = "diary")
 public class Diary {
 
-    // DB 에서 인식하기 위한 PK
-    @PrimaryKey(autoGenerate = true)
-    @ColumnInfo(name = "id")
     private final int id;
-
-    // 저장한 날
-    @ColumnInfo(name = "recordDate")
-    @NonNull
     private final String recordDate;
-
-    // 저장된 파일 경로
-    @ColumnInfo(name = "recordFilePath")
-    @NonNull
     private final String recordFilePath;
-
-    // 설정한 태그들
-    @ColumnInfo(name = "tags")
     private final String tags;
-
-    // 선택한 감정 번호
-    @ColumnInfo(name = "selectedEmotion")
     private final int selectedEmotion;
-
-    // API 를 통해 분석된 감정
-    @ColumnInfo(name = "analyzedEmotion")
-    private final int analyzedEmotion;
-
-    // TimeStamp 추가
-    @ColumnInfo(name = "timeStamp")
-    private final long timeStamp;
 
     public Diary(int id,
                  @NonNull String recordDate,
                  @NonNull String recordFilePath,
                  @NonNull String tags,
-                 final int selectedEmotion,
-                 final int analyzedEmotion,
-                 final long timeStamp) {
+                 final int selectedEmotion) {
         this.id = id;
         this.recordDate = recordDate;
         this.recordFilePath = recordFilePath;
         this.tags = tags;
         this.selectedEmotion = selectedEmotion;
-        this.analyzedEmotion = analyzedEmotion;
-        this.timeStamp = timeStamp;
     }
 
     /*최대한 안바뀌게 -> final */
@@ -89,50 +46,5 @@ public class Diary {
 
     public int getSelectedEmotion() {
         return selectedEmotion;
-    }
-
-    public int getAnalyzedEmotion() {
-        return analyzedEmotion;
-    }
-
-    public long getTimeStamp() {
-        return timeStamp;
-    }
-
-    public static Diary[] generateSampleDiaryData() {
-        String filePath = "/storage/emulated/0/2019-02-08.acc";
-        File file = new File("/storage/emulated/0/2019-02-08.acc");
-
-        if (!file.exists()) {
-            try {
-                boolean isCreated = file.createNewFile();
-                if (!isCreated) {
-                    Log.e("Test", "파일 생성 실패");
-                } else {
-                    Log.e("Test", "파일 생성 성공");
-                }
-            } catch (IOException e) {
-                e.printStackTrace();
-            }
-        }
-
-        Random random = new Random();
-
-        List<Diary> samples = new ArrayList<>();
-
-        for (int i = 1; i <= 20; ++i) {
-            samples.add(new Diary(
-                    i,
-                    String.format(Locale.getDefault(), "2019-01-%2d", i),
-                    filePath,
-                    String.format(Locale.getDefault(), "#%d번", i),
-                    Math.abs(random.nextInt() % 5),
-                    Math.abs(random.nextInt() % 5),
-                    new Date().getTime() / 1000 + i * 10
-            ));
-        }
-
-        Diary[] temp = new Diary[samples.size()];
-        return temp;
     }
 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/model/Recommendation.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/model/Recommendation.java
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo;
 import androidx.room.Entity;
 import androidx.room.ForeignKey;
 import androidx.room.PrimaryKey;
+import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
 
 import static androidx.room.ForeignKey.CASCADE;
 
@@ -14,7 +15,7 @@ import static androidx.room.ForeignKey.CASCADE;
 */
 
 @Entity(tableName = "recommended", foreignKeys = {
-        @ForeignKey(entity = Diary.class,
+        @ForeignKey(entity = DiaryEntity.class,
                 parentColumns = "id",
                 childColumns = "diaryId",
                 onDelete = CASCADE),

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryEntityMapper.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryEntityMapper.java
@@ -1,0 +1,31 @@
+package teamh.boostcamp.myapplication.data.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
+import teamh.boostcamp.myapplication.data.model.Diary;
+
+class DiaryEntityMapper {
+
+    static List<Diary> toDiaryList(List<DiaryEntity> entityList) {
+
+        int size = entityList.size();
+
+        List<Diary> diaryList = new ArrayList<>(size);
+
+        for (int i = 0; i < size; ++i) {
+            // 순서대로
+            final DiaryEntity diaryEntity = entityList.get(i);
+            diaryList.add(new Diary(
+                    diaryEntity.getId(),
+                    diaryEntity.getRecordDate(),
+                    diaryEntity.getRecordFilePath(),
+                    diaryEntity.getTags(),
+                    diaryEntity.getSelectedEmotion()
+            ));
+        }
+
+        return diaryList;
+    }
+}

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepository.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepository.java
@@ -6,10 +6,11 @@ import androidx.annotation.NonNull;
 import io.reactivex.Completable;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
+import teamh.boostcamp.myapplication.data.local.room.dao.DiaryDao;
+import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
 import teamh.boostcamp.myapplication.data.model.Diary;
 import teamh.boostcamp.myapplication.data.remote.apis.deepaffects.DeepAffectApiClient;
 import teamh.boostcamp.myapplication.data.remote.apis.deepaffects.request.EmotionAnalyzeRequest;
-import teamh.boostcamp.myapplication.data.local.room.dao.DiaryDao;
 
 
 /*
@@ -40,19 +41,15 @@ public class DiaryRepository implements DiaryRepositoryContract {
 
     @NonNull
     @Override
-    public Single<List<Diary>> loadMoreDiaryItems(final long idx) {
-        return diaryDao.loadMoreDiary(idx).subscribeOn(Schedulers.io());
+    public Single<List<Diary>> loadMoreDiaryItems(final int idx) {
+        return diaryDao.loadMoreDiary(idx)
+                .map(DiaryEntityMapper::toDiaryList)
+                .subscribeOn(Schedulers.io());
     }
 
     @NonNull
     @Override
-    public Completable deleteRecordItem(@NonNull Diary diary) {
-        return diaryDao.deleteDiary(diary).subscribeOn(Schedulers.io());
-    }
-
-    @NonNull
-    @Override
-    public Completable insertRecordItem(@NonNull Diary diaryItem) {
+    public Completable insertRecordItem(@NonNull DiaryEntity diaryItem) {
         return diaryDao.insertDiary(diaryItem).subscribeOn(Schedulers.io());
     }
 
@@ -64,7 +61,7 @@ public class DiaryRepository implements DiaryRepositoryContract {
                 .subscribeOn(Schedulers.io());
     }
 
-    @NonNull
+    /*@NonNull
     @Override
     public Completable clearAllData() {
         return Completable.fromAction(() -> diaryDao.deleteAll())
@@ -73,10 +70,14 @@ public class DiaryRepository implements DiaryRepositoryContract {
 
     @NonNull
     @Override
-    public Completable insertRecordItems(@NonNull Diary... diaries) {
+    public Completable insertRecordItems(@NonNull DiaryEntity... diaries) {
         return diaryDao.insertDiary(diaries)
                 .subscribeOn(Schedulers.io());
     }
 
-
+    @NonNull
+    @Override
+    public Completable deleteRecordItem(@NonNull DiaryEntity diary) {
+        return diaryDao.deleteDiary(diary).subscribeOn(Schedulers.io());
+    }*/
 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepositoryContract.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepositoryContract.java
@@ -5,26 +5,27 @@ import java.util.List;
 import androidx.annotation.NonNull;
 import io.reactivex.Completable;
 import io.reactivex.Single;
+import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
 import teamh.boostcamp.myapplication.data.remote.apis.deepaffects.request.EmotionAnalyzeRequest;
 import teamh.boostcamp.myapplication.data.model.Diary;
 
 public interface DiaryRepositoryContract {
 
     @NonNull
-    Single<List<Diary>> loadMoreDiaryItems(final long idx);
+    Single<List<Diary>> loadMoreDiaryItems(final int idx);
 
     @NonNull
     Single<Integer> analyzeVoiceEmotion(@NonNull EmotionAnalyzeRequest request);
 
     @NonNull
-    Completable insertRecordItem(@NonNull Diary diaryItem);
+    Completable insertRecordItem(@NonNull DiaryEntity diaryItem);
+/*
+    @NonNull
+    Completable insertRecordItems(@NonNull DiaryEntity... diaries);
 
     @NonNull
-    Completable insertRecordItems(@NonNull Diary... diaries);
+    Completable deleteRecordItem(@NonNull DiaryEntity diary);
 
     @NonNull
-    Completable deleteRecordItem(@NonNull Diary diary);
-
-    @NonNull
-    Completable clearAllData();
+    Completable clearAllData();*/
 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/LegacyDiaryRepository.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/LegacyDiaryRepository.java
@@ -1,0 +1,83 @@
+package teamh.boostcamp.myapplication.data.repository;
+
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import io.reactivex.Completable;
+import io.reactivex.Single;
+import io.reactivex.schedulers.Schedulers;
+import teamh.boostcamp.myapplication.data.local.room.dao.DiaryDao;
+import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
+import teamh.boostcamp.myapplication.data.model.Diary;
+import teamh.boostcamp.myapplication.data.remote.apis.deepaffects.DeepAffectApiClient;
+import teamh.boostcamp.myapplication.data.remote.apis.deepaffects.request.EmotionAnalyzeRequest;
+
+
+/*
+ * Repository 를 data/repository + 가공까지 ! */
+public class LegacyDiaryRepository implements LegacyDiaryRepositoryContract {
+
+    private static LegacyDiaryRepository INSTANCE;
+    private DeepAffectApiClient deepAffectApiClient;
+    private DiaryDao diaryDao;
+
+    private LegacyDiaryRepository(@NonNull DeepAffectApiClient deepAffectApiClient,
+                                  @NonNull DiaryDao diaryDao) {
+        this.deepAffectApiClient = deepAffectApiClient;
+        this.diaryDao = diaryDao;
+    }
+
+    public static LegacyDiaryRepository getInstance(@NonNull DeepAffectApiClient deepAffectApiClient,
+                                                    @NonNull DiaryDao diaryDao) {
+        if (INSTANCE == null) {
+            synchronized (LegacyDiaryRepository.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = new LegacyDiaryRepository(deepAffectApiClient, diaryDao);
+                }
+            }
+        }
+        return INSTANCE;
+    }
+
+    @NonNull
+    @Override
+    public Single<List<Diary>> loadMoreDiaryItems(final int idx) {
+        return diaryDao.loadMoreDiary(idx)
+                .map(DiaryEntityMapper::toDiaryList)
+                .subscribeOn(Schedulers.io());
+    }
+
+    @NonNull
+    @Override
+    public Completable insertRecordItem(@NonNull DiaryEntity diaryItem) {
+        return diaryDao.insertDiary(diaryItem).subscribeOn(Schedulers.io());
+    }
+
+    @NonNull
+    @Override
+    public Single<Integer> analyzeVoiceEmotion(@NonNull EmotionAnalyzeRequest request) {
+        return deepAffectApiClient.analyzeVoiceEmotion(request)
+                .map(AnalyzedEmotionMapper::parseAnalyzedEmotion)
+                .subscribeOn(Schedulers.io());
+    }
+
+    /*@NonNull
+    @Override
+    public Completable clearAllData() {
+        return Completable.fromAction(() -> diaryDao.deleteAll())
+                .subscribeOn(Schedulers.io());
+    }
+
+    @NonNull
+    @Override
+    public Completable insertRecordItems(@NonNull DiaryEntity... diaries) {
+        return diaryDao.insertDiary(diaries)
+                .subscribeOn(Schedulers.io());
+    }
+
+    @NonNull
+    @Override
+    public Completable deleteRecordItem(@NonNull DiaryEntity diary) {
+        return diaryDao.deleteDiary(diary).subscribeOn(Schedulers.io());
+    }*/
+}

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/LegacyDiaryRepositoryContract.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/LegacyDiaryRepositoryContract.java
@@ -9,7 +9,7 @@ import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
 import teamh.boostcamp.myapplication.data.remote.apis.deepaffects.request.EmotionAnalyzeRequest;
 import teamh.boostcamp.myapplication.data.model.Diary;
 
-public interface DiaryRepositoryContract {
+public interface LegacyDiaryRepositoryContract {
 
     @NonNull
     Single<List<Diary>> loadMoreDiaryItems(final int idx);

--- a/app/src/main/java/teamh/boostcamp/myapplication/view/diarylist/DiaryListFragment.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/view/diarylist/DiaryListFragment.java
@@ -23,7 +23,7 @@ import io.reactivex.disposables.CompositeDisposable;
 import teamh.boostcamp.myapplication.R;
 import teamh.boostcamp.myapplication.data.model.Diary;
 import teamh.boostcamp.myapplication.data.remote.apis.deepaffects.DeepAffectApiClient;
-import teamh.boostcamp.myapplication.data.repository.DiaryRepository;
+import teamh.boostcamp.myapplication.data.repository.LegacyDiaryRepository;
 import teamh.boostcamp.myapplication.data.local.room.AppDatabase;
 import teamh.boostcamp.myapplication.databinding.FragmentDiaryListBinding;
 import teamh.boostcamp.myapplication.utils.KeyPadUtil;
@@ -156,7 +156,7 @@ public class DiaryListFragment extends BaseFragment<FragmentDiaryListBinding> im
 
         // 주입
         presenter = new DiaryPresenter(this,
-                DiaryRepository.getInstance(DeepAffectApiClient.getInstance(), AppDatabase.getInstance(context).diaryDao()),
+                LegacyDiaryRepository.getInstance(DeepAffectApiClient.getInstance(), AppDatabase.getInstance(context).diaryDao()),
                 diaryRecorder);
     }
 

--- a/app/src/main/java/teamh/boostcamp/myapplication/view/diarylist/DiaryPresenter.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/view/diarylist/DiaryPresenter.java
@@ -11,7 +11,7 @@ import java.util.Date;
 import androidx.annotation.NonNull;
 import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
-import teamh.boostcamp.myapplication.data.model.Diary;
+import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
 import teamh.boostcamp.myapplication.data.remote.apis.deepaffects.request.EmotionAnalyzeRequest;
 import teamh.boostcamp.myapplication.data.repository.DiaryRepository;
 
@@ -27,7 +27,7 @@ public class DiaryPresenter implements DiaryContract.Presenter {
     private CompositeDisposable compositeDisposable;
 
     private int selectedEmotion = -1;
-    private long currentIdx = Long.MAX_VALUE;
+    private int currentIdx = Integer.MAX_VALUE;
     private boolean isRecording = false;
     private boolean isLoadingItem = false;
 
@@ -109,7 +109,7 @@ public class DiaryPresenter implements DiaryContract.Presenter {
         // 분석 후 저장
         compositeDisposable.add(diaryRepository.analyzeVoiceEmotion(request)
                 .doOnError(throwable -> view.showEmotionAnalyzeFailMessage())
-                .map(analyzedEmotion -> new Diary(0,
+                .map(analyzedEmotion -> new DiaryEntity(0,
                         file.getName().split("\\.")[0],
                         diaryRecorderImpl.getFilePath(),
                         tags,
@@ -133,13 +133,6 @@ public class DiaryPresenter implements DiaryContract.Presenter {
 
     @Override
     public void loadMoreDiaryItems() {
- /*       compositeDisposable.add(diaryRepository.clearAllData()
-                .subscribe(() -> {
-                            Log.e("Test", "성공");
-                        }, throwable -> {
-                            Log.e("Test", "실패");
-                        }
-                ));*/
 
         if (!isLoadingItem) {
             isLoadingItem = true;
@@ -149,7 +142,7 @@ public class DiaryPresenter implements DiaryContract.Presenter {
 
                                 isLoadingItem = false;
                                 if (diaryList.size() != 0) {
-                                    currentIdx = diaryList.get(diaryList.size() - 1).getTimeStamp();
+                                    currentIdx = diaryList.get(diaryList.size() - 1).getId();
                                 } else {
                                     return;
                                 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/view/diarylist/DiaryPresenter.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/view/diarylist/DiaryPresenter.java
@@ -13,7 +13,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
 import teamh.boostcamp.myapplication.data.remote.apis.deepaffects.request.EmotionAnalyzeRequest;
-import teamh.boostcamp.myapplication.data.repository.DiaryRepository;
+import teamh.boostcamp.myapplication.data.repository.LegacyDiaryRepository;
 
 public class DiaryPresenter implements DiaryContract.Presenter {
 
@@ -21,7 +21,7 @@ public class DiaryPresenter implements DiaryContract.Presenter {
 
     private DiaryContract.View view;
 
-    private DiaryRepository diaryRepository;
+    private LegacyDiaryRepository diaryRepository;
     private DiaryRecorder diaryRecorderImpl;
 
     private CompositeDisposable compositeDisposable;
@@ -32,7 +32,7 @@ public class DiaryPresenter implements DiaryContract.Presenter {
     private boolean isLoadingItem = false;
 
     DiaryPresenter(@NonNull DiaryContract.View view,
-                   @NonNull DiaryRepository diaryRepository,
+                   @NonNull LegacyDiaryRepository diaryRepository,
                    @NonNull DiaryRecorder diaryRecorderImpl) {
         this.view = view;
         this.diaryRepository = diaryRepository;

--- a/app/src/main/java/teamh/boostcamp/myapplication/view/play/PlayPresenter.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/view/play/PlayPresenter.java
@@ -33,7 +33,7 @@ public class PlayPresenter implements PlayContractor.Presenter {
     @Override
     public void loadData(int MemoryId) {
         compositeDisposable.add(
-                appDatabase.appDao().loadSelectedDiayLista(MemoryId)
+                appDatabase.appDao().loadSelectedDiaryLista(MemoryId)
                         .subscribeOn(Schedulers.io())
                         .observeOn(AndroidSchedulers.mainThread())
                         .subscribe(list -> {


### PR DESCRIPTION
## 개요
- Diary Class 재작성
- DiaryRepository Interface 작성

## 작업사항
- LegacyDiary를 만들기 전에 Diary, DiaryEntity 로 변경했습니다.
( LegacyDiary가 DiaryEnity 와 동일합니다 )
- DiaryRepository Interface 를 작성했습니다.
    - 일기 목록 가져오기
    - 목소리 감정 분석 결과 불러오기
    - 일기 저장
    - 일기 목록 초기화
