### PR TITLE
#111 DiaryRepository Interface 작성

### DIFF
--- a/app/src/main/java/teamh/boostcamp/myapplication/data/model/Diary.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/model/Diary.java
@@ -1,5 +1,6 @@
 package teamh.boostcamp.myapplication.data.model;
 
+import java.util.Date;
 import java.util.List;
 
 import androidx.annotation.NonNull;
@@ -8,7 +9,7 @@ import androidx.annotation.Nullable;
 public class Diary {
 
     @NonNull
-    private final String recordDate;
+    private final Date recordDate;
     @NonNull
     private final String recordFilePath;
     @Nullable
@@ -18,7 +19,7 @@ public class Diary {
     private final int id;
 
     public Diary(int id,
-                 @NonNull final String recordDate,
+                 @NonNull final Date recordDate,
                  @NonNull final String recordFilePath,
                  @Nullable final List<String> tags,
                  @NonNull final Emotion selectedEmotion) {
@@ -34,7 +35,7 @@ public class Diary {
     }
 
     @NonNull
-    public String getRecordDate() {
+    public Date getRecordDate() {
         return recordDate;
     }
 

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepository.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepository.java
@@ -1,5 +1,6 @@
 package teamh.boostcamp.myapplication.data.repository;
 
+import java.util.Date;
 import java.util.List;
 
 import androidx.annotation.NonNull;
@@ -9,5 +10,6 @@ import teamh.boostcamp.myapplication.data.model.Diary;
 public interface DiaryRepository {
 
     @NonNull
-    Single<List<Diary>> loadDiaryList(final int lastItemId, final int pageSize);
+    Single<List<Diary>> loadDiaryList(@NonNull final Date lastItemSavedTime,
+                                      final int pageSize);
 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepository.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepository.java
@@ -3,18 +3,11 @@ package teamh.boostcamp.myapplication.data.repository;
 import java.util.List;
 
 import androidx.annotation.NonNull;
-import io.reactivex.Completable;
 import io.reactivex.Single;
 import teamh.boostcamp.myapplication.data.model.Diary;
 
 public interface DiaryRepository {
 
     @NonNull
-    Single<List<Diary>> loadMoreDiaries(final int idx);
-
-    @NonNull
-    Completable insertDiaries(@NonNull Diary ...diaries);
-
-    @NonNull
-    Completable truncateDiaries();
+    Single<List<Diary>> loadDiaryList(final int lastItemIndex, final int amount);
 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepository.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepository.java
@@ -1,0 +1,20 @@
+package teamh.boostcamp.myapplication.data.repository;
+
+import java.util.List;
+
+import androidx.annotation.NonNull;
+import io.reactivex.Completable;
+import io.reactivex.Single;
+import teamh.boostcamp.myapplication.data.model.Diary;
+
+public interface DiaryRepository {
+
+    @NonNull
+    Single<List<Diary>> loadMoreDiaries(final int idx);
+
+    @NonNull
+    Completable insertDiaries(@NonNull Diary ...diaries);
+
+    @NonNull
+    Completable truncateDiaries();
+}

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepository.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepository.java
@@ -9,5 +9,5 @@ import teamh.boostcamp.myapplication.data.model.Diary;
 public interface DiaryRepository {
 
     @NonNull
-    Single<List<Diary>> loadDiaryList(final int lastItemIndex, final int amount);
+    Single<List<Diary>> loadDiaryList(final int lastItemIndex, final int pageSize);
 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepository.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/DiaryRepository.java
@@ -9,5 +9,5 @@ import teamh.boostcamp.myapplication.data.model.Diary;
 public interface DiaryRepository {
 
     @NonNull
-    Single<List<Diary>> loadDiaryList(final int lastItemIndex, final int pageSize);
+    Single<List<Diary>> loadDiaryList(final int lastItemId, final int pageSize);
 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/LegacyDiaryRepository.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/LegacyDiaryRepository.java
@@ -14,24 +14,24 @@ import teamh.boostcamp.myapplication.data.local.room.dao.DiaryDao;
 
 /*
  * Repository 를 data/repository + 가공까지 ! */
-public class DiaryRepository implements DiaryRepositoryContract {
+public class LegacyDiaryRepository implements LegacyDiaryRepositoryContract {
 
-    private static DiaryRepository INSTANCE;
+    private static LegacyDiaryRepository INSTANCE;
     private DeepAffectApiClient deepAffectApiClient;
     private DiaryDao diaryDao;
 
-    private DiaryRepository(@NonNull DeepAffectApiClient deepAffectApiClient,
-                            @NonNull DiaryDao diaryDao) {
+    private LegacyDiaryRepository(@NonNull DeepAffectApiClient deepAffectApiClient,
+                                  @NonNull DiaryDao diaryDao) {
         this.deepAffectApiClient = deepAffectApiClient;
         this.diaryDao = diaryDao;
     }
 
-    public static DiaryRepository getInstance(@NonNull DeepAffectApiClient deepAffectApiClient,
-                                              @NonNull DiaryDao diaryDao) {
+    public static LegacyDiaryRepository getInstance(@NonNull DeepAffectApiClient deepAffectApiClient,
+                                                    @NonNull DiaryDao diaryDao) {
         if (INSTANCE == null) {
-            synchronized (DiaryRepository.class) {
+            synchronized (LegacyDiaryRepository.class) {
                 if (INSTANCE == null) {
-                    INSTANCE = new DiaryRepository(deepAffectApiClient, diaryDao);
+                    INSTANCE = new LegacyDiaryRepository(deepAffectApiClient, diaryDao);
                 }
             }
         }

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/LegacyDiaryRepositoryContract.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/LegacyDiaryRepositoryContract.java
@@ -8,7 +8,7 @@ import io.reactivex.Single;
 import teamh.boostcamp.myapplication.data.model.LegacyDiary;
 import teamh.boostcamp.myapplication.data.remote.apis.deepaffects.request.EmotionAnalyzeRequest;
 
-public interface DiaryRepositoryContract {
+public interface LegacyDiaryRepositoryContract {
 
     @NonNull
     Single<List<LegacyDiary>> loadMoreDiaryItems(final long idx);

--- a/app/src/main/java/teamh/boostcamp/myapplication/view/diarylist/DiaryListFragment.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/view/diarylist/DiaryListFragment.java
@@ -23,7 +23,7 @@ import io.reactivex.disposables.CompositeDisposable;
 import teamh.boostcamp.myapplication.R;
 import teamh.boostcamp.myapplication.data.model.LegacyDiary;
 import teamh.boostcamp.myapplication.data.remote.apis.deepaffects.DeepAffectApiClient;
-import teamh.boostcamp.myapplication.data.repository.DiaryRepository;
+import teamh.boostcamp.myapplication.data.repository.LegacyDiaryRepository;
 import teamh.boostcamp.myapplication.data.local.room.AppDatabase;
 import teamh.boostcamp.myapplication.databinding.FragmentDiaryListBinding;
 import teamh.boostcamp.myapplication.utils.KeyPadUtil;
@@ -156,7 +156,7 @@ public class DiaryListFragment extends BaseFragment<FragmentDiaryListBinding> im
 
         // 주입
         presenter = new DiaryPresenter(this,
-                DiaryRepository.getInstance(DeepAffectApiClient.getInstance(), AppDatabase.getInstance(context).diaryDao()),
+                LegacyDiaryRepository.getInstance(DeepAffectApiClient.getInstance(), AppDatabase.getInstance(context).diaryDao()),
                 diaryRecorder);
     }
 

--- a/app/src/main/java/teamh/boostcamp/myapplication/view/diarylist/DiaryPresenter.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/view/diarylist/DiaryPresenter.java
@@ -13,7 +13,7 @@ import io.reactivex.android.schedulers.AndroidSchedulers;
 import io.reactivex.disposables.CompositeDisposable;
 import teamh.boostcamp.myapplication.data.model.LegacyDiary;
 import teamh.boostcamp.myapplication.data.remote.apis.deepaffects.request.EmotionAnalyzeRequest;
-import teamh.boostcamp.myapplication.data.repository.DiaryRepository;
+import teamh.boostcamp.myapplication.data.repository.LegacyDiaryRepository;
 
 public class DiaryPresenter implements DiaryContract.Presenter {
 
@@ -21,7 +21,7 @@ public class DiaryPresenter implements DiaryContract.Presenter {
 
     private DiaryContract.View view;
 
-    private DiaryRepository diaryRepository;
+    private LegacyDiaryRepository diaryRepository;
     private DiaryRecorder diaryRecorderImpl;
 
     private CompositeDisposable compositeDisposable;
@@ -32,7 +32,7 @@ public class DiaryPresenter implements DiaryContract.Presenter {
     private boolean isLoadingItem = false;
 
     DiaryPresenter(@NonNull DiaryContract.View view,
-                   @NonNull DiaryRepository diaryRepository,
+                   @NonNull LegacyDiaryRepository diaryRepository,
                    @NonNull DiaryRecorder diaryRecorderImpl) {
         this.view = view;
         this.diaryRepository = diaryRepository;


### PR DESCRIPTION
## 개요
- 기존 DiaryRepository Interface 이름 변경 (DiaryRepositoryContract -> LegacyDiaryRepositoryContract)
- DiaryRepository Interface 작성

## 작업사항
- DiaryRepository Interface 작성
    - insert      : 일기 입력 목적
    - truncate : 일기 초기화 목적
    - select     : n개의 일기를 가져오기 위한 목적

resolved #111 