### PR TITLE
#139-추억생성기능 repository 인터페이스 및 구현, #142-추억 로드 오류수정 

### DIFF
--- a/app/src/main/java/teamh/boostcamp/myapplication/data/local/room/AppDatabase.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/local/room/AppDatabase.java
@@ -24,14 +24,13 @@ import teamh.boostcamp.myapplication.data.local.room.converter.EmotionTypeConver
 import teamh.boostcamp.myapplication.data.local.room.converter.StringListTypeConverter;
 import teamh.boostcamp.myapplication.data.local.room.dao.AppDao;
 import teamh.boostcamp.myapplication.data.local.room.dao.DiaryDao;
-
 import teamh.boostcamp.myapplication.data.local.room.dao.LegacyDiaryDao;
-import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
-import teamh.boostcamp.myapplication.data.model.Emotion;
 import teamh.boostcamp.myapplication.data.local.room.dao.RecallDao;
+import teamh.boostcamp.myapplication.data.local.room.entity.DiaryEntity;
+import teamh.boostcamp.myapplication.data.local.room.entity.RecallEntity;
+import teamh.boostcamp.myapplication.data.model.Emotion;
 import teamh.boostcamp.myapplication.data.model.LegacyDiary;
 import teamh.boostcamp.myapplication.data.model.Memory;
-import teamh.boostcamp.myapplication.data.local.room.entity.RecallEntity;
 import teamh.boostcamp.myapplication.data.model.Recommendation;
 
 @Database(entities = {LegacyDiary.class, Recommendation.class, Memory.class, DiaryEntity.class, RecallEntity.class}, version = 5, exportSchema = false)
@@ -72,14 +71,14 @@ public abstract class AppDatabase extends RoomDatabase {
                                     List<DiaryEntity> samples = new ArrayList<>();
 
                                     final long TODAY = new Date().getTime();
-                                    final long DAY = 86400L;
+                                    final long DAY = 86400000L;
 
                                     for (int i = 1; i <= 20; ++i) {
                                         samples.add(new DiaryEntity(
                                                 i,
                                                 new Date(TODAY - DAY * i),
                                                 filePath,
-                                                Arrays.asList(String.format("#%2d번",i)),
+                                                Arrays.asList(String.format("#%2d번", i)),
                                                 Emotion.fromValue(Math.abs(random.nextInt() % 5)),
                                                 Emotion.fromValue(Math.abs(random.nextInt() % 5))
                                         ));
@@ -90,10 +89,21 @@ public abstract class AppDatabase extends RoomDatabase {
                                     Completable.fromAction(() -> INSTANCE.diaryDao()
                                             .insert(samples.toArray(temp)))
                                             .subscribeOn(Schedulers.io())
-                                            .subscribe(() -> { Log.d("Test", "데이터 저장");
+                                            .subscribe(() -> {
+                                                        Log.d("Test", "데이터 저장");
                                                     },
-                                                    throwable -> {throwable.printStackTrace();
+                                                    throwable -> {
+                                                        throwable.printStackTrace();
                                                     });
+
+                                    RecallEntity[] recallList = {new RecallEntity(0, new Date(), Emotion.fromValue(0))
+                                            , new RecallEntity(0, new Date(), Emotion.fromValue(1))
+                                    , new RecallEntity(0, new Date(), Emotion.fromValue(2))
+                                    , new RecallEntity(0, new Date(), Emotion.fromValue(3))};
+
+                                    Completable.fromAction(() -> INSTANCE.recallDao().insertRecall(recallList))
+                                    .subscribeOn(Schedulers.io())
+                                    .subscribe();
                                 }
                             })
                             .build();

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/local/room/dao/RecallDao.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/local/room/dao/RecallDao.java
@@ -2,7 +2,10 @@ package teamh.boostcamp.myapplication.data.local.room.dao;
 
 import java.util.List;
 
+import androidx.annotation.NonNull;
 import androidx.room.Dao;
+import androidx.room.Insert;
+import androidx.room.OnConflictStrategy;
 import androidx.room.Query;
 import io.reactivex.Single;
 import teamh.boostcamp.myapplication.data.local.room.entity.RecallEntity;
@@ -12,4 +15,8 @@ public interface RecallDao {
 
     @Query("Select * FROM recalls ORDER BY createdDate")
     Single<List<RecallEntity>> loadRecallEntities();
+
+    @Insert(onConflict = OnConflictStrategy.ABORT)
+    void insertRecall(@NonNull RecallEntity...recallEntities);
+
 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/RecallRepository.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/RecallRepository.java
@@ -3,7 +3,9 @@ package teamh.boostcamp.myapplication.data.repository;
 import java.util.List;
 
 import androidx.annotation.NonNull;
+import io.reactivex.Completable;
 import io.reactivex.Single;
+import teamh.boostcamp.myapplication.data.local.room.entity.RecallEntity;
 import teamh.boostcamp.myapplication.data.model.Recall;
 
 public interface RecallRepository {
@@ -12,6 +14,6 @@ public interface RecallRepository {
     Single<List<Recall>> loadRecallList();
 
     @NonNull
-    void insertRecall();
+    Completable insertRecall(RecallEntity recallEntity);
 
 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/RecallRepository.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/RecallRepository.java
@@ -11,4 +11,7 @@ public interface RecallRepository {
     @NonNull
     Single<List<Recall>> loadRecallList();
 
+    @NonNull
+    void insertRecall();
+
 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/RecallRepositoryImpl.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/RecallRepositoryImpl.java
@@ -49,6 +49,12 @@ public class RecallRepositoryImpl implements RecallRepository {
     }
 
     @NonNull
+    @Override
+    public void insertRecall() {
+
+    }
+
+    @NonNull
     private Date generateStartDate(@NonNull Date endDate) {
         return new Date(endDate.getTime()
                 - TimeUnit.DAYS.toMillis(14)

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/repository/RecallRepositoryImpl.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/repository/RecallRepositoryImpl.java
@@ -5,10 +5,13 @@ import java.util.List;
 import java.util.concurrent.TimeUnit;
 
 import androidx.annotation.NonNull;
+import io.reactivex.Completable;
 import io.reactivex.Observable;
+import io.reactivex.Scheduler;
 import io.reactivex.Single;
 import io.reactivex.schedulers.Schedulers;
 import teamh.boostcamp.myapplication.data.local.room.AppDatabase;
+import teamh.boostcamp.myapplication.data.local.room.entity.RecallEntity;
 import teamh.boostcamp.myapplication.data.model.Recall;
 
 public class RecallRepositoryImpl implements RecallRepository {
@@ -50,8 +53,9 @@ public class RecallRepositoryImpl implements RecallRepository {
 
     @NonNull
     @Override
-    public void insertRecall() {
-
+    public Completable insertRecall(@NonNull final RecallEntity recallEntity) {
+        return Completable.fromAction(() -> appDatabase.recallDao().insertRecall(recallEntity))
+                .subscribeOn(Schedulers.io());
     }
 
     @NonNull

--- a/app/src/main/java/teamh/boostcamp/myapplication/view/recall/DiaryTitleListAdapter.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/view/recall/DiaryTitleListAdapter.java
@@ -15,10 +15,8 @@ import teamh.boostcamp.myapplication.data.model.Diary;
 import teamh.boostcamp.myapplication.databinding.ItemDiarytitleLlistBinding;
 
 public class DiaryTitleListAdapter extends RecyclerView.Adapter<DiaryTitleListAdapter.ViewHolder>{
-
-    @NonNull
+    private static final SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd", Locale.KOREA);
     private Context context;
-    @NonNull
     private List<Diary> diaryList;
 
     public DiaryTitleListAdapter(@NonNull Context context) {
@@ -37,8 +35,6 @@ public class DiaryTitleListAdapter extends RecyclerView.Adapter<DiaryTitleListAd
 
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd", Locale.KOREA);
-
         Diary diary = diaryList.get(position);
         holder.binding.tvDiaryTitle.setText(simpleDateFormat.format(diary.getRecordDate()));
         // Fixme Emotion enum 수정후 변경

--- a/app/src/main/java/teamh/boostcamp/myapplication/view/recall/DiaryTitleListAdapter.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/view/recall/DiaryTitleListAdapter.java
@@ -4,8 +4,10 @@ import android.content.Context;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Locale;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.RecyclerView;
@@ -35,8 +37,11 @@ public class DiaryTitleListAdapter extends RecyclerView.Adapter<DiaryTitleListAd
 
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("yyyyMMdd", Locale.KOREA);
+
         Diary diary = diaryList.get(position);
-        holder.binding.tvDiaryTitle.setText(diary.getRecordDate().toString());
+        holder.binding.tvDiaryTitle.setText(simpleDateFormat.format(diary.getRecordDate()));
+        // Fixme Emotion enum 수정후 변경
         holder.binding.tvEmoji.setText(diary.getSelectedEmotion().getEmotion()+"");
     }
 

--- a/app/src/main/java/teamh/boostcamp/myapplication/view/recall/RecallFragment.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/view/recall/RecallFragment.java
@@ -56,6 +56,8 @@ public class RecallFragment extends Fragment implements RecallView {
     }
 
     private void initRecyclerView() {
+        binding.rvCard.setHasFixedSize(true);
+        binding.rvCard.setVerticalScrollbarPosition(0);
         recallListAdapter = new RecallListAdapter(getContext());
         binding.rvCard.setLayoutManager(new LinearLayoutManager(getContext()));
         binding.rvCard.setAdapter(recallListAdapter);

--- a/app/src/main/java/teamh/boostcamp/myapplication/view/recall/RecallListAdapter.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/view/recall/RecallListAdapter.java
@@ -1,11 +1,15 @@
 package teamh.boostcamp.myapplication.view.recall;
 
 import android.content.Context;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
+import java.util.Locale;
 
 import androidx.annotation.NonNull;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -14,7 +18,6 @@ import teamh.boostcamp.myapplication.data.model.Recall;
 import teamh.boostcamp.myapplication.databinding.ItemRecallListBinding;
 
 public class RecallListAdapter extends RecyclerView.Adapter<RecallListAdapter.ViewHolder> {
-
     @NonNull
     private Context context;
     @NonNull
@@ -37,8 +40,9 @@ public class RecallListAdapter extends RecyclerView.Adapter<RecallListAdapter.Vi
 
     @Override
     public void onBindViewHolder(@NonNull ViewHolder holder, int position) {
-
-        holder.binding.tvSubTitle.setText(itemList.get(position).getStartDate()+"~"+itemList.get(position).getEndDate());
+        holder.binding.tvSubTitle.setText(generateRecallTitle(itemList.get(position)));
+        holder.binding.rvDiary.setHasFixedSize(true);
+        holder.binding.rvDiary.setVerticalScrollbarPosition(0);
         holder.binding.rvDiary.setLayoutManager(new LinearLayoutManager(context));
 
         DiaryTitleListAdapter adapter = new DiaryTitleListAdapter(context);
@@ -64,6 +68,47 @@ public class RecallListAdapter extends RecyclerView.Adapter<RecallListAdapter.Vi
             super(binding.getRoot());
             this.binding = binding;
         }
+    }
+
+    @NonNull
+    private String generateRecallTitle(@NonNull Recall recall) {
+        String startDateString = DateToSimpleFormat(recall.getStartDate());
+        String endDateString = DateToSimpleFormat(recall.getEndDate());
+        String emotionString = emotionToString(recall.getEmotion().getEmotion());
+        return String.format("%s 부터 %s까지의 %s 날들", startDateString, endDateString, emotionString);
+    }
+
+    @NonNull
+    private String DateToSimpleFormat(Date date) {
+        SimpleDateFormat simpleDateFormat = new SimpleDateFormat("MM월 dd일", Locale.KOREA);
+        return simpleDateFormat.format(date);
+    }
+
+    @NonNull
+    private String emotionToString(int emotion) {
+        String emotionString;
+
+        switch (emotion) {
+            case 0:
+                emotionString = "끔찍한";
+                break;
+            case 1:
+                emotionString = "나쁜";
+                break;
+            case 2:
+                emotionString = "그저그런";
+                break;
+            case 3:
+                emotionString = "즐거운";
+                break;
+            case 4:
+                emotionString = "정말 행복했던";
+                break;
+            default:
+                emotionString = "오류";
+        }
+
+        return emotionString;
     }
 
 }

--- a/app/src/main/java/teamh/boostcamp/myapplication/view/recall/RecallListAdapter.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/view/recall/RecallListAdapter.java
@@ -1,7 +1,6 @@
 package teamh.boostcamp.myapplication.view.recall;
 
 import android.content.Context;
-import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
 
@@ -75,7 +74,7 @@ public class RecallListAdapter extends RecyclerView.Adapter<RecallListAdapter.Vi
         String startDateString = DateToSimpleFormat(recall.getStartDate());
         String endDateString = DateToSimpleFormat(recall.getEndDate());
         String emotionString = emotionToString(recall.getEmotion().getEmotion());
-        return String.format("%s 부터 %s까지의 %s 날들", startDateString, endDateString, emotionString);
+        return String.format("%s 부터 %s까지의 %s", startDateString, endDateString, emotionString);
     }
 
     @NonNull
@@ -86,29 +85,20 @@ public class RecallListAdapter extends RecyclerView.Adapter<RecallListAdapter.Vi
 
     @NonNull
     private String emotionToString(int emotion) {
-        String emotionString;
-
         switch (emotion) {
             case 0:
-                emotionString = "끔찍한";
-                break;
+                return "불행함들";
             case 1:
-                emotionString = "나쁜";
-                break;
+                return "슬픔들";
             case 2:
-                emotionString = "그저그런";
-                break;
+                return "그저그런날들";
             case 3:
-                emotionString = "즐거운";
-                break;
+                return "즐거움들";
             case 4:
-                emotionString = "정말 행복했던";
-                break;
+                return "행복들";
             default:
-                emotionString = "오류";
+                return "행복들";
         }
-
-        return emotionString;
     }
 
 }


### PR DESCRIPTION
#139 , #142 브랜치를 잘못 하여 두 작업이 섞여 버렸습니다. 이점 양해 바랍니다.

## 개요
추억을 생성하기 위한 repository 인터페이스 및 구현
추억 로드 작업 오류 수정

## 작업사항
추억 새 데이터를 추가하였습니다.
추억화면 recycler view이 안보이던 것을 수정하였습니다.
추억화면 recycler view의 title을 수정하였습니다.
