### PR TITLE
#232 firebase analytics 추가

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -95,5 +95,7 @@ dependencies {
     implementation group: 'com.kakao.sdk', name: 'kakaolink', version: project.KAKAO_SDK_VERSION
     // Crashlytics
     implementation 'com.crashlytics.sdk.android:crashlytics:2.9.9'
+    // Analytics
+    implementation 'com.google.firebase:firebase-core:16.0.6'
 }
 apply plugin: 'com.google.gms.google-services'

--- a/app/src/main/java/teamh/boostcamp/myapplication/data/model/LogEvent.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/data/model/LogEvent.java
@@ -1,0 +1,44 @@
+package teamh.boostcamp.myapplication.data.model;
+
+import androidx.annotation.NonNull;
+
+public enum LogEvent {
+
+    RECORD_DIARY_BUTTON_CLICK("buttonClick", "recordDiary", "recordButtonClick", "buttonClick"),
+    DONE_BUTTON_CLICK("buttonClick", "recordDone", "recordDoneButtonClick", "save record");
+
+    private final String eventName;
+    private final String itemId;
+    private final String itemName;
+    private final String contentType;
+
+    LogEvent(@NonNull String eventName,
+             @NonNull String itemId,
+             @NonNull String itemName,
+             @NonNull String contentType) {
+        this.eventName = eventName;
+        this.itemId = itemId;
+        this.itemName = itemName;
+        this.contentType = contentType;
+    }
+
+    @NonNull
+    public String getEventName() {
+        return eventName;
+    }
+
+    @NonNull
+    public String getItemId() {
+        return itemId;
+    }
+
+    @NonNull
+    public String getItemName() {
+        return itemName;
+    }
+
+    @NonNull
+    public String getContentType() {
+        return contentType;
+    }
+}

--- a/app/src/main/java/teamh/boostcamp/myapplication/utils/FirebaseEventLogger.java
+++ b/app/src/main/java/teamh/boostcamp/myapplication/utils/FirebaseEventLogger.java
@@ -1,0 +1,39 @@
+package teamh.boostcamp.myapplication.utils;
+
+import android.content.Context;
+import android.os.Bundle;
+
+import com.google.firebase.analytics.FirebaseAnalytics;
+
+import androidx.annotation.NonNull;
+import teamh.boostcamp.myapplication.data.model.LogEvent;
+
+public class FirebaseEventLogger {
+
+    private static volatile FirebaseEventLogger INSTANCE;
+
+    private volatile FirebaseAnalytics logger;
+
+    private FirebaseEventLogger(@NonNull Context context) {
+        logger = FirebaseAnalytics.getInstance(context);
+    }
+
+    public static FirebaseEventLogger getInstance(@NonNull Context context) {
+        if (INSTANCE == null) {
+            synchronized (FirebaseEventLogger.class) {
+                if (INSTANCE == null) {
+                    INSTANCE = new FirebaseEventLogger(context.getApplicationContext());
+                }
+            }
+        }
+        return INSTANCE;
+    }
+
+    public void addLogEvent(@NonNull LogEvent logEvent) {
+        Bundle eventData = new Bundle();
+        eventData.putString(FirebaseAnalytics.Param.ITEM_ID, logEvent.getItemId());
+        eventData.putString(FirebaseAnalytics.Param.ITEM_NAME, logEvent.getItemName());
+        eventData.putString(FirebaseAnalytics.Param.CONTENT_TYPE, logEvent.getContentType());
+        logger.logEvent(logEvent.getEventName(), eventData);
+    }
+}


### PR DESCRIPTION
## 개요
firebase analytics 추가

## 작업사항
firebaseAnalytics 를 사용하기 쉽게 FirebaseEventLogger 클래스 추가
LogEvent enum 을 추가

## 사용방법
먼저 Firebase 에 남는 Log 를 LogEvent enum 으로 통일하여 작성
LogEvent 는 필요한 event 를 직접 작성해서 사용가능

FirebaseEventLogger 는 Singleton 클래스로 context 를 넘겨 instance 를 받아와 사용할 수 있음.
받아온 instacne 를 통해 addLogEvent 함수로 LogEvent 를 로그를 남길 수 있음

